### PR TITLE
Center page content and make header transparent

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,10 +26,8 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <div className="container mx-auto">
-          <Nav />
-          {children}
-        </div>
+        <Nav />
+        {children}
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,8 +26,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <Nav />
-        {children}
+        <div className="container mx-auto">
+          <Nav />
+          {children}
+        </div>
       </body>
     </html>
   );

--- a/src/components/hero/index.tsx
+++ b/src/components/hero/index.tsx
@@ -20,32 +20,34 @@ export default function Hero() {
       <div className="absolute inset-0 bg-gradient-to-r from-black/55 via-black/25 to-transparent" />
 
       {/* Promo card (matches your layout: title -> gold band -> subtext -> phone) */}
-      <div className="absolute left-6 md:left-16 bottom-16 z-20 max-w-xl">
-        <motion.div
-          initial={{ y: 18, opacity: 0 }}
-          animate={{ y: 0, opacity: 1 }}
-          transition={{
-            type: "spring",
-            stiffness: 80,
-            damping: 18,
-            delay: 0.1,
-          }}
-          className="backdrop-blur-sm bg-black/30 shadow-promo border border-hive-600/50 rounded"
-        >
-          <div className="p-5 md:p-6">
-            <p className="text-xl md:text-2xl text-white/90">Transform Your Space</p>
-            <div className="mt-3 bg-hive-500 px-4 py-3 inline-block">
-              <p className="text-3xl md:text-5xl font-extrabold tracking-tight">GET 20% OFF</p>
+      <div className="container mx-auto relative z-20 h-full">
+        <div className="absolute left-6 md:left-16 bottom-16 max-w-xl">
+          <motion.div
+            initial={{ y: 18, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{
+              type: "spring",
+              stiffness: 80,
+              damping: 18,
+              delay: 0.1,
+            }}
+            className="backdrop-blur-sm bg-black/30 shadow-promo border border-hive-600/50 rounded"
+          >
+            <div className="p-5 md:p-6">
+              <p className="text-xl md:text-2xl text-white/90">Transform Your Space</p>
+              <div className="mt-3 bg-hive-500 px-4 py-3 inline-block">
+                <p className="text-3xl md:text-5xl font-extrabold tracking-tight">GET 20% OFF</p>
+              </div>
+              <p className="mt-3 text-white/85 text-lg md:text-xl">Your First Design Project!</p>
+              <p className="mt-1 text-xl md:text-2xl font-semibold">
+                Call Now{" "}
+                <a href="tel:7897895027" className="underline">
+                  789 789 5027
+                </a>
+              </p>
             </div>
-            <p className="mt-3 text-white/85 text-lg md:text-xl">Your First Design Project!</p>
-            <p className="mt-1 text-xl md:text-2xl font-semibold">
-              Call Now{" "}
-              <a href="tel:7897895027" className="underline">
-                789 789 5027
-              </a>
-            </p>
-          </div>
-        </motion.div>
+          </motion.div>
+        </div>
       </div>
     </section>
   );

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -14,24 +14,26 @@ const items = ["About us", "Services", "Testimonials", "Contact"];
 
 export default function Nav() {
   return (
-    <nav className="flex items-center justify-between p-6 bg-transparent">
-      <Link href="/" className="flex items-center gap-3">
-        <Image src="/logo-mark.svg" alt="IntoHive logo" width={200} height={100} />
-      </Link>
-      <NavigationMenu>
-        <NavigationMenuList>
-          {items.map((item) => (
-            <NavigationMenuItem key={item}>
-              <NavigationMenuLink
-                href={`#${item.toLowerCase().replace(/\s+/g, "-")}`}
-                className={navigationMenuTriggerStyle()}
-              >
-                {item}
-              </NavigationMenuLink>
-            </NavigationMenuItem>
-          ))}
-        </NavigationMenuList>
-      </NavigationMenu>
+    <nav className="bg-transparent">
+      <div className="container mx-auto flex items-center justify-between p-6">
+        <Link href="/" className="flex items-center gap-3">
+          <Image src="/logo-mark.svg" alt="IntoHive logo" width={200} height={100} />
+        </Link>
+        <NavigationMenu>
+          <NavigationMenuList>
+            {items.map((item) => (
+              <NavigationMenuItem key={item}>
+                <NavigationMenuLink
+                  href={`#${item.toLowerCase().replace(/\s+/g, "-")}`}
+                  className={navigationMenuTriggerStyle()}
+                >
+                  {item}
+                </NavigationMenuLink>
+              </NavigationMenuItem>
+            ))}
+          </NavigationMenuList>
+        </NavigationMenu>
+      </div>
     </nav>
   );
 }

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -14,7 +14,7 @@ const items = ["About us", "Services", "Testimonials", "Contact"];
 
 export default function Nav() {
   return (
-    <nav className="flex items-center justify-between p-6">
+    <nav className="flex items-center justify-between p-6 bg-transparent">
       <Link href="/" className="flex items-center gap-3">
         <Image src="/logo-mark.svg" alt="IntoHive logo" width={200} height={100} />
       </Link>


### PR DESCRIPTION
## Summary
- Wrap application with a container to center page content
- Remove header background to allow transparent navigation

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch font file from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_689f30870fe88330a091cff3867c2836