### PR TITLE
Add carousel background to hero section

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@react-three/fiber": "^9.3.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "embla-carousel-autoplay": "^8.6.0",
+    "embla-carousel-react": "^8.6.0",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.539.0",
     "next": "15.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      embla-carousel-autoplay:
+        specifier: ^8.6.0
+        version: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-react:
+        specifier: ^8.6.0
+        version: 8.6.0(react@19.1.0)
       framer-motion:
         specifier: ^12.23.12
         version: 12.23.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -767,6 +773,24 @@ packages:
 
   draco3d@1.5.7:
     resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
+
+  embla-carousel-autoplay@8.6.0:
+    resolution: {integrity: sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel-react@8.6.0:
+    resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
+  embla-carousel-reactive-utils@8.6.0:
+    resolution: {integrity: sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel@8.6.0:
+    resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
 
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
@@ -1761,6 +1785,22 @@ snapshots:
   detect-libc@2.0.4: {}
 
   draco3d@1.5.7: {}
+
+  embla-carousel-autoplay@8.6.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel-react@8.6.0(react@19.1.0):
+    dependencies:
+      embla-carousel: 8.6.0
+      embla-carousel-reactive-utils: 8.6.0(embla-carousel@8.6.0)
+      react: 19.1.0
+
+  embla-carousel-reactive-utils@8.6.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel@8.6.0: {}
 
   enhanced-resolve@5.18.3:
     dependencies:

--- a/src/components/hero/index.tsx
+++ b/src/components/hero/index.tsx
@@ -1,51 +1,68 @@
 "use client";
 
+import Autoplay from "embla-carousel-autoplay";
 import { motion } from "framer-motion";
 import Image from "next/image";
+import { Carousel, CarouselContent, CarouselItem } from "@/components/ui/carousel";
 
 export default function Hero() {
+  const images = ["/hero.jpg"];
+
   return (
     <section className="relative min-h-screen w-full overflow-hidden">
-      {/* Background: Figma hero render */}
-      <Image
-        src="/hero.jpg"
-        alt="Modern house"
-        fill
-        priority
-        className="object-cover"
-        sizes="100vw"
-      />
+      <Carousel
+        className="absolute inset-0"
+        opts={{ loop: true }}
+        plugins={[Autoplay({ delay: 5000 })]}
+      >
+        <CarouselContent className="h-full">
+          {images.map((src) => (
+            <CarouselItem key={src} className="relative h-full">
+              <Image
+                src={src}
+                alt="Modern house"
+                fill
+                priority={src === images[0]}
+                className="object-cover"
+                sizes="100vw"
+              />
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+      </Carousel>
 
       {/* Subtle left-to-right veil for text contrast */}
       <div className="absolute inset-0 bg-gradient-to-r from-black/55 via-black/25 to-transparent" />
 
       {/* Promo card (matches your layout: title -> gold band -> subtext -> phone) */}
-      <div className="absolute left-6 md:left-16 bottom-16 z-20 max-w-xl">
-        <motion.div
-          initial={{ y: 18, opacity: 0 }}
-          animate={{ y: 0, opacity: 1 }}
-          transition={{
-            type: "spring",
-            stiffness: 80,
-            damping: 18,
-            delay: 0.1,
-          }}
-          className="backdrop-blur-sm bg-black/30 shadow-promo border border-hive-600/50 rounded"
-        >
-          <div className="p-5 md:p-6">
-            <p className="text-xl md:text-2xl text-white/90">Transform Your Space</p>
-            <div className="mt-3 bg-hive-500 px-4 py-3 inline-block">
-              <p className="text-3xl md:text-5xl font-extrabold tracking-tight">GET 20% OFF</p>
+      <div className="container mx-auto relative z-20 h-full">
+        <div className="absolute left-6 md:left-16 bottom-16 max-w-xl">
+          <motion.div
+            initial={{ y: 18, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{
+              type: "spring",
+              stiffness: 80,
+              damping: 18,
+              delay: 0.1,
+            }}
+            className="backdrop-blur-sm bg-black/30 shadow-promo border border-hive-600/50 rounded"
+          >
+            <div className="p-5 md:p-6">
+              <p className="text-xl md:text-2xl text-white/90">Transform Your Space</p>
+              <div className="mt-3 bg-hive-500 px-4 py-3 inline-block">
+                <p className="text-3xl md:text-5xl font-extrabold tracking-tight">GET 20% OFF</p>
+              </div>
+              <p className="mt-3 text-white/85 text-lg md:text-xl">Your First Design Project!</p>
+              <p className="mt-1 text-xl md:text-2xl font-semibold">
+                Call Now{" "}
+                <a href="tel:7897895027" className="underline">
+                  789 789 5027
+                </a>
+              </p>
             </div>
-            <p className="mt-3 text-white/85 text-lg md:text-xl">Your First Design Project!</p>
-            <p className="mt-1 text-xl md:text-2xl font-semibold">
-              Call Now{" "}
-              <a href="tel:7897895027" className="underline">
-                789 789 5027
-              </a>
-            </p>
-          </div>
-        </motion.div>
+          </motion.div>
+        </div>
       </div>
     </section>
   );

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -14,24 +14,26 @@ const items = ["About us", "Services", "Testimonials", "Contact"];
 
 export default function Nav() {
   return (
-    <nav className="flex items-center justify-between p-6">
-      <Link href="/" className="flex items-center gap-3">
-        <Image src="/logo-mark.svg" alt="IntoHive logo" width={200} height={100} />
-      </Link>
-      <NavigationMenu>
-        <NavigationMenuList>
-          {items.map((item) => (
-            <NavigationMenuItem key={item}>
-              <NavigationMenuLink
-                href={`#${item.toLowerCase().replace(/\s+/g, "-")}`}
-                className={navigationMenuTriggerStyle()}
-              >
-                {item}
-              </NavigationMenuLink>
-            </NavigationMenuItem>
-          ))}
-        </NavigationMenuList>
-      </NavigationMenu>
+    <nav className="bg-transparent">
+      <div className="container mx-auto flex items-center justify-between p-6">
+        <Link href="/" className="flex items-center gap-3">
+          <Image src="/logo-mark.svg" alt="IntoHive logo" width={200} height={100} />
+        </Link>
+        <NavigationMenu>
+          <NavigationMenuList>
+            {items.map((item) => (
+              <NavigationMenuItem key={item}>
+                <NavigationMenuLink
+                  href={`#${item.toLowerCase().replace(/\s+/g, "-")}`}
+                  className={navigationMenuTriggerStyle()}
+                >
+                  {item}
+                </NavigationMenuLink>
+              </NavigationMenuItem>
+            ))}
+          </NavigationMenuList>
+        </NavigationMenu>
+      </div>
     </nav>
   );
 }

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import type { EmblaOptionsType, EmblaPluginType } from "embla-carousel";
+import useEmblaCarousel from "embla-carousel-react";
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type CarouselProps = React.HTMLAttributes<HTMLDivElement> & {
+  opts?: EmblaOptionsType;
+  plugins?: EmblaPluginType[];
+  orientation?: "horizontal" | "vertical";
+};
+
+interface CarouselContextType {
+  embla: ReturnType<typeof useEmblaCarousel>[1];
+  orientation: "horizontal" | "vertical";
+}
+
+const CarouselContext = React.createContext<CarouselContextType | null>(null);
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext);
+  if (!context) {
+    throw new Error("useCarousel must be used within <Carousel>");
+  }
+  return context;
+}
+
+const Carousel = React.forwardRef<HTMLDivElement, CarouselProps>(
+  ({ orientation = "horizontal", opts, plugins = [], className, children, ...props }, ref) => {
+    const [carouselRef, embla] = useEmblaCarousel(
+      {
+        ...opts,
+        axis: orientation === "horizontal" ? "x" : "y",
+      },
+      plugins,
+    );
+
+    return (
+      <CarouselContext.Provider value={{ embla, orientation }}>
+        <div ref={ref} className={cn("relative", className)} {...props}>
+          <div ref={carouselRef} className="h-full w-full overflow-hidden">
+            {children}
+          </div>
+        </div>
+      </CarouselContext.Provider>
+    );
+  },
+);
+Carousel.displayName = "Carousel";
+
+const CarouselContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => {
+    const { orientation } = useCarousel();
+    return (
+      <div
+        ref={ref}
+        className={cn("flex h-full", orientation === "vertical" && "flex-col", className)}
+        {...props}
+      />
+    );
+  },
+);
+CarouselContent.displayName = "CarouselContent";
+
+const CarouselItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("relative min-w-full", className)} {...props} />
+  ),
+);
+CarouselItem.displayName = "CarouselItem";
+
+export { Carousel, CarouselContent, CarouselItem, useCarousel };


### PR DESCRIPTION
## Summary
- Introduce Embla-based carousel component from Shadcn UI
- Use carousel to cycle hero background images across the full viewport
- Install Embla dependencies for carousel autoplay support
- Remove unused hero-2 and hero-3 images, simplifying hero background list

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch `Geist` and `Geist Mono` fonts from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_689f30870fe88330a091cff3867c2836