### PR TITLE
Center sections using reusable container component

### DIFF
--- a/src/components/about/index.tsx
+++ b/src/components/about/index.tsx
@@ -1,9 +1,10 @@
 import Image from "next/image";
+import { Container } from "@/components/ui/container";
 
 export default function About() {
   return (
     <section className="py-16">
-      <div className="mx-auto max-w-7xl px-6 md:px-8">
+      <Container>
         <div className="grid gap-12 md:grid-cols-2 md:items-start">
           <div>
             <h2 className="text-4xl font-bold mb-6">About us</h2>
@@ -47,7 +48,7 @@ export default function About() {
             </div>
           </div>
         </div>
-      </div>
+      </Container>
     </section>
   );
 }

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -3,11 +3,12 @@
 import { Facebook, Instagram, Linkedin, Mail, Phone, Twitter } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { Container } from "@/components/ui/container";
 
 export default function Footer() {
   return (
     <footer className="bg-neutral-900 text-white">
-      <div className="mx-auto max-w-7xl px-6 py-10">
+      <Container className="py-10">
         <div className="flex flex-col gap-10 md:flex-row md:items-start md:justify-between">
           {/* Logo and contact */}
           <div className="flex flex-col gap-6 md:w-1/3">
@@ -84,7 +85,7 @@ export default function Footer() {
         <div className="mt-10 border-t border-white/10 pt-4 text-xs text-white/60">
           ©2024 IntoHive. All rights reserved.
         </div>
-      </div>
+      </Container>
     </footer>
   );
 }

--- a/src/components/hero/index.tsx
+++ b/src/components/hero/index.tsx
@@ -4,6 +4,7 @@ import Autoplay from "embla-carousel-autoplay";
 import { motion } from "framer-motion";
 import Image from "next/image";
 import { Carousel, CarouselContent, CarouselItem } from "@/components/ui/carousel";
+import { Container } from "@/components/ui/container";
 
 export default function Hero() {
   const images = ["/hero.jpg"];
@@ -35,7 +36,7 @@ export default function Hero() {
       <div className="absolute inset-0 bg-gradient-to-r from-black/55 via-black/25 to-transparent" />
 
       {/* Promo card (matches your layout: title -> gold band -> subtext -> phone) */}
-      <div className="container mx-auto relative z-20 h-full">
+      <Container className="relative z-20 h-full">
         <div className="absolute left-6 md:left-16 bottom-16 max-w-xl">
           <motion.div
             initial={{ y: 18, opacity: 0 }}
@@ -63,7 +64,7 @@ export default function Hero() {
             </div>
           </motion.div>
         </div>
-      </div>
+      </Container>
     </section>
   );
 }

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -2,6 +2,9 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { useEffect, useState } from "react";
+import { Container } from "@/components/ui/container";
+import { cn } from "@/lib/utils";
 import {
   NavigationMenu,
   NavigationMenuItem,
@@ -13,9 +16,22 @@ import {
 const items = ["About us", "Services", "Testimonials", "Contact"];
 
 export default function Nav() {
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 0);
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
   return (
-    <nav className="bg-transparent">
-      <div className="container mx-auto flex items-center justify-between p-6">
+    <nav
+      className={cn(
+        "sticky top-0 z-50 w-full transition-colors",
+        scrolled ? "bg-black" : "bg-transparent",
+      )}
+    >
+      <Container className="flex items-center justify-between p-6">
         <Link href="/" className="flex items-center gap-3">
           <Image src="/logo-mark.svg" alt="IntoHive logo" width={200} height={100} />
         </Link>
@@ -33,7 +49,7 @@ export default function Nav() {
             ))}
           </NavigationMenuList>
         </NavigationMenu>
-      </div>
+      </Container>
     </nav>
   );
 }

--- a/src/components/ui/container.tsx
+++ b/src/components/ui/container.tsx
@@ -1,0 +1,6 @@
+import type { HTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+export function Container({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("container mx-auto px-6 md:px-8", className)} {...props} />;
+}


### PR DESCRIPTION
## Summary
- add reusable Container component for consistent centering
- wrap nav, about, footer, and hero overlay in Container while keeping hero carousel full-width
- make navbar transparent, sticky, and black on scroll

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch font file from `fonts.gstatic.com`)*

------
https://chatgpt.com/codex/tasks/task_b_689f423c8a308330ac6a1caac9e6a07c