### PR TITLE
feat: add horizontally scrollable portfolio section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import About from "@/components/about";
 import Footer from "@/components/footer";
 import Hero from "@/components/hero";
+import Portfolio from "@/components/portfolio";
 
 export default function Home() {
   return (
@@ -8,6 +9,7 @@ export default function Home() {
       <main>
         <Hero />
         <About />
+        <Portfolio />
       </main>
       <Footer />
     </>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,6 +2,7 @@ import About from "./about";
 import Footer from "./footer";
 import Hero from "./hero";
 import Nav from "./navbar";
+import Portfolio from "./portfolio";
 import ThreeLogo from "./threelogo";
 
-export { About, Hero, Nav, ThreeLogo, Footer };
+export { About, Footer, Hero, Nav, Portfolio, ThreeLogo };

--- a/src/components/portfolio/index.tsx
+++ b/src/components/portfolio/index.tsx
@@ -1,0 +1,65 @@
+import { Plus } from "lucide-react";
+import Image from "next/image";
+import { Card, CardContent } from "@/components/ui/card";
+
+export default function Portfolio() {
+  const projects = [
+    {
+      title: "Modern Living",
+      image:
+        "https://images.unsplash.com/photo-1505691723518-36a9b47d2d30?auto=format&fit=crop&w=800&q=80",
+    },
+    {
+      title: "Dining Elegance",
+      image:
+        "https://images.unsplash.com/photo-1596079890741-4496c3766a1a?auto=format&fit=crop&w=800&q=80",
+    },
+    {
+      title: "Kitchen Inspiration",
+      image:
+        "https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&fit=crop&w=800&q=80",
+    },
+    {
+      title: "Cozy Bedroom",
+      image:
+        "https://images.unsplash.com/photo-1602524819883-459b6cf59cc6?auto=format&fit=crop&w=800&q=80",
+    },
+  ];
+
+  return (
+    <section className="py-16">
+      <div className="mx-auto max-w-7xl px-6 md:px-8">
+        <h2 className="mb-6 text-4xl font-bold">Portfolio</h2>
+        <div className="flex gap-6 overflow-x-auto pb-4">
+          {projects.map((project) => (
+            <Card key={project.title} className="relative h-96 min-w-[280px] overflow-hidden">
+              <CardContent className="relative h-full w-full p-0">
+                <Image
+                  src={project.image}
+                  alt={project.title}
+                  fill
+                  sizes="250px"
+                  className="object-cover"
+                />
+              </CardContent>
+              <div className="absolute bottom-4 left-1/2 -translate-x-1/2">
+                <div className="flex h-9 w-9 items-center justify-center rounded-full bg-hive-500 text-white">
+                  <Plus className="h-5 w-5" />
+                </div>
+              </div>
+              <div className="absolute inset-0 flex items-end justify-center bg-black/60 opacity-0 transition-opacity hover:opacity-100">
+                <button
+                  type="button"
+                  className="mb-6 flex items-center gap-2 rounded-full bg-hive-500 px-4 py-2 text-white"
+                >
+                  View Project
+                  <Plus className="h-4 w-4" />
+                </button>
+              </div>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)}
+      {...props}
+    />
+  ),
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+  ),
+);
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3
+      ref={ref}
+      className={cn("text-2xl font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  ),
+);
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  ),
+);
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+  ),
+);
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle };


### PR DESCRIPTION
## Summary
- add shadcn Card component for reuse
- create Portfolio section with horizontally scrollable project cards
- include portfolio section on home page

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_689f45985d508330983a360ada166037