### PR TITLE
Improve responsiveness and local service images

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Nav } from "@/components";
@@ -16,6 +16,11 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "IntoHive — Transform Your Space",
   description: "Architecture & interior design studio",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Menu } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -17,6 +18,7 @@ const items = ["About us", "Services", "Testimonials", "Contact"];
 
 export default function Nav() {
   const [scrolled, setScrolled] = useState(false);
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 0);
@@ -35,7 +37,7 @@ export default function Nav() {
         <Link href="/" className="flex items-center gap-3">
           <Image src="/logo-mark.svg" alt="IntoHive logo" width={200} height={100} />
         </Link>
-        <NavigationMenu>
+        <NavigationMenu className="hidden md:block">
           <NavigationMenuList>
             {items.map((item) => (
               <NavigationMenuItem key={item}>
@@ -52,7 +54,32 @@ export default function Nav() {
             ))}
           </NavigationMenuList>
         </NavigationMenu>
+        <button
+          type="button"
+          className="md:hidden"
+          onClick={() => setOpen((prev) => !prev)}
+          aria-label="Toggle Menu"
+        >
+          <Menu />
+        </button>
       </Container>
+      {open && (
+        <div className="md:hidden bg-black text-white">
+          <ul className="flex flex-col p-4 space-y-2">
+            {items.map((item) => (
+              <li key={item}>
+                <Link
+                  href={`#${item.toLowerCase().replace(/\s+/g, "-")}`}
+                  onClick={() => setOpen(false)}
+                  className="block w-full py-2"
+                >
+                  {item}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </nav>
   );
 }

--- a/src/components/services/index.tsx
+++ b/src/components/services/index.tsx
@@ -51,18 +51,20 @@ export default function Services() {
             transition={{ duration: 0.6 }}
           >
             <Image
-              src="https://images.unsplash.com/photo-1507086182420-83d4af51e6f8?auto=format&fit=crop&w=600&q=80"
+              src="/service-1.jpg"
               alt="Interior design"
               width={600}
               height={400}
-              className="rounded-md object-cover"
+              sizes="(max-width: 768px) 100vw, 600px"
+              className="w-full h-auto rounded-md object-cover"
             />
             <Image
-              src="https://images.unsplash.com/photo-1507084830850-5367e9d0b640?auto=format&fit=crop&w=600&q=80"
+              src="/service-2.jpg"
               alt="Modern architecture"
               width={600}
               height={400}
-              className="rounded-md object-cover"
+              sizes="(max-width: 768px) 100vw, 600px"
+              className="w-full h-auto rounded-md object-cover"
             />
           </motion.div>
         </div>


### PR DESCRIPTION
## Summary
- serve service section images from local assets for consistency
- add responsive viewport settings and mobile navigation

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_689f539f4280833096be8a3291a6502b