### PR TITLE
feat: switch to Nunito Sans font

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Nunito Sans](https://fonts.google.com/specimen/Nunito+Sans).
 
 ## Learn More
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,22 +7,17 @@
   --foreground: #171717;
   --primary: #b27429;
   --primary-foreground: #ffffff;
-}
 
-@theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-primary: var(--primary);
   --color-primary-foreground: var(--primary-foreground);
-  
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-nunito-sans), sans-serif;
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,10 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Nunito_Sans } from "next/font/google";
 import "./globals.css";
 import { Nav } from "@/components";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const nunitoSans = Nunito_Sans({
+  variable: "--font-nunito-sans",
   subsets: ["latin"],
 });
 
@@ -29,8 +24,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+    <html lang="en" className={nunitoSans.variable}>
+      <body className="antialiased">
         <Nav />
         {children}
       </body>


### PR DESCRIPTION
## Summary
- replace Geist fonts with Nunito Sans from next/font/google
- update global styles to use Nunito Sans and apply its variable to the `<html>` element
- fix global `font-family` to reference `var(--font-nunito-sans)` so Nunito Sans is applied site-wide
- adjust README to mention new font

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_689f60a4e73c83308f20403f2b0c5f05