### PR TITLE
Refactor footer layout into two-row grid

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -9,10 +9,12 @@ export default function Footer() {
   return (
     <footer className="bg-[var(--header-footer-bg)] text-[var(--header-footer-text)]">
       <div className="mx-auto max-w-7xl px-6 py-12">
-        <div className="grid gap-10 md:grid-cols-12">
-          {/* Logo and contact */}
-          <div className="flex flex-col gap-6 md:col-span-3">
+        {/* Row 1: logo and contact */}
+        <div className="grid gap-10 md:grid-cols-2">
+          <div>
             <Image src="/logo-mark.svg" alt="IntoHive logo" width={180} height={60} priority />
+          </div>
+          <div className="flex flex-col items-start gap-6 md:items-end">
             <ul className="space-y-3 text-sm text-white/90">
               <li className="flex items-center gap-3">
                 <span className="flex h-8 w-8 items-center justify-center rounded-full bg-hive-500/20">
@@ -27,40 +29,6 @@ export default function Footer() {
                 <span>info@intohive.in</span>
               </li>
             </ul>
-          </div>
-
-          {/* Addresses */}
-          <div className="md:col-span-6">
-            <div className="grid grid-cols-1 overflow-hidden rounded-md border border-white/10 text-sm md:grid-cols-3">
-              <div className="space-y-2 p-6 md:p-8">
-                <h4 className="font-semibold">Chennai</h4>
-                <p className="text-white/80">
-                  Nest Vibrant, Sowmya Nagar,
-                  <br />
-                  Perumbakkam – 600100
-                </p>
-              </div>
-              <div className="space-y-2 border-t border-white/10 p-6 md:border-l md:border-t-0 md:p-8">
-                <h4 className="font-semibold">Coimbatore</h4>
-                <p className="text-white/80">
-                  Rani Maigai, Near Rajalakshmi Mills,
-                  <br />
-                  Kalimadai – 641005
-                </p>
-              </div>
-              <div className="space-y-2 border-t border-white/10 p-6 md:border-l md:border-t-0 md:p-8">
-                <h4 className="font-semibold">Erode</h4>
-                <p className="text-white/80">
-                  NPS Anbu Nagar, Nanjundapuram,
-                  <br />
-                  Industrial Estate – 638104
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* Actions */}
-          <div className="flex flex-col gap-6 md:col-span-3">
             <Link
               href="#"
               className="rounded-md border border-[var(--header-footer-text)] px-4 py-2 text-center text-sm font-medium text-[var(--header-footer-text)] transition-colors hover:bg-[var(--header-footer-text)] hover:text-[var(--header-footer-bg)]"
@@ -102,6 +70,37 @@ export default function Footer() {
             </div>
           </div>
         </div>
+
+        {/* Row 2: addresses */}
+        <div className="mt-10">
+          <div className="grid grid-cols-1 overflow-hidden rounded-md border border-white/10 text-sm md:grid-cols-3">
+            <div className="space-y-2 p-6 md:p-8">
+              <h4 className="font-semibold">Chennai</h4>
+              <p className="text-white/80">
+                Nest Vibrant, Sowmya Nagar,
+                <br />
+                Perumbakkam – 600100
+              </p>
+            </div>
+            <div className="space-y-2 border-t border-white/10 p-6 md:border-l md:border-t-0 md:p-8">
+              <h4 className="font-semibold">Coimbatore</h4>
+              <p className="text-white/80">
+                Rani Maigai, Near Rajalakshmi Mills,
+                <br />
+                Kalimadai – 641005
+              </p>
+            </div>
+            <div className="space-y-2 border-t border-white/10 p-6 md:border-l md:border-t-0 md:p-8">
+              <h4 className="font-semibold">Erode</h4>
+              <p className="text-white/80">
+                NPS Anbu Nagar, Nanjundapuram,
+                <br />
+                Industrial Estate – 638104
+              </p>
+            </div>
+          </div>
+        </div>
+
         <div className="mt-10 border-t border-white/10 pt-4 text-center text-xs text-white/60">
           ©{year} IntoHive. All rights reserved.
         </div>


### PR DESCRIPTION
## Summary
- redesign footer with a two-column first row (logo left, contact and actions right)
- present addresses across a separate three-column row

## Testing
- `pnpm format`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68a0230b725083309b59510e69d9951b